### PR TITLE
Remove enforcing linting status check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -126,8 +126,7 @@ branches:
           teams: []
       required_status_checks:
         strict: true
-        contexts:
-          - linting
+        contexts: []
       enforce_admins: true
       restrictions:
         apps: []


### PR DESCRIPTION
@p-j-smith expressed concern about this in https://github.com/UCL-MIRSG/.github/pull/47#pullrequestreview-1689938011

Turns out this is what happens for a repo that doesn't have the status check, so probably makes sense to remove
![image](https://github.com/UCL-MIRSG/admin/assets/15052188/9141141f-fb31-438a-9641-64a59daf6bfb)
