### PR TITLE
Remove default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,4 +1,5 @@
 # These settings are synced to GitHub by https://github.com/github/safe-settings
+
 repository:
   allow_auto_merge: true
   allow_merge_commit: false

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,11 +1,9 @@
 # These settings are synced to GitHub by https://github.com/github/safe-settings
-
 repository:
   allow_auto_merge: true
   allow_merge_commit: false
   allow_rebase_merge: false
   allow_update_branch: true
-  default_branch: main
   delete_branch_on_merge: true
   has_discussions: false
   has_downloads: false


### PR DESCRIPTION
Having this in has forced everything to be changed to `main`. This was probably useful for old repos which still had `master`. However, it does mean https://github.com/UCL-MIRSG/UCLH-MPBE-SRR-XNAT which had the default as `dev` got changed too. Now we've got rid of `master` let's get rid of this setting.