### PR TITLE
Turn off required status checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -35,7 +35,5 @@ branches:
           teams: []
         dismissal_restrictions: {}
       required_status_checks:
-        strict: true
-        contexts: []
       enforce_admins: true
       restrictions:


### PR DESCRIPTION
So I had tested this in the `.github` repo, but I think something is configured so that repo behaves differently to others.

Turns out, having the `context: []` means that anything you enable `safe-settings` will re-enable. We could fill that with `linting` but not all repos have that workflow + I think this would then limit others to add. So better not have that setting at all. Discussed here github/safe-settings#412.

Note, in general, we do want required status checks. For now, we will just have to apply them manually.