### PR TITLE
Don't suggest to update branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,7 +4,6 @@ repository:
   allow_auto_merge: true
   allow_merge_commit: false
   allow_rebase_merge: false
-  allow_update_branch: true
   delete_branch_on_merge: true
   has_discussions: false
   has_downloads: false


### PR DESCRIPTION
This is another idea to reduce CI use. We will be warned about conflicting files in the normal way. Defaults to `false` https://docs.github.com/en/rest/repos/repos.