### PR TITLE
Switch from `branch protection` to `rulesets`

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,4 +1,6 @@
 # These settings are synced to GitHub by https://github.com/github/safe-settings
+# Example config:
+# https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/settings.yml
 ---
 repository:
   allow_auto_merge: true
@@ -15,26 +17,41 @@ teams:
   - name: mirsg
     permission: admin
 
-# Each top-level element under branch protection must be filled. If one doesn't
-# want to use one of them you must set it to empty. Otherwise, none of the
-# settings will be applied.
-branches:
-  # `default` creates a branch protection rule to against the repo's base branch
-  - name: default
-    protection:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: false
-        require_last_push_approval: false
-        bypass_pull_request_allowances:
-          apps:
-            - renovate
-          users:
-          teams:
-        dismissal_restrictions:
-          users:
-          teams:
-      required_status_checks:
-      enforce_admins: true
-      restrictions:
+# See available options:
+# https://docs.github.com/en/rest/orgs/rules#create-an-organization-repository-rulesetfor
+rulesets:
+  - name: Default
+    target: branch
+    enforcement: active
+
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+
+    rules:
+      - type: deletion
+      - type: non_fast_forward # prevents force pushes
+
+  - name: Pull Requests
+    target: branch
+    enforcement: active
+
+    bypass_actors:
+      - actor_id: 2740 # Renovate Bot
+        actor_type: Integration
+        bypass_mode: always
+
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+
+    rules:
+      - type: pull_request
+        parameters:
+          dismiss_stale_reviews_on_push: true
+          require_code_owner_review: false
+          require_last_push_approval: false
+          required_approving_review_count: 1
+          required_review_thread_resolution: false


### PR DESCRIPTION
It seems that GitHub has now defaulted to `rulesets`
![image](https://github.com/UCL-MIRSG/admin/assets/15052188/f9061b36-b7c1-43c0-962c-ee718c530075)

The app https://github.com/github/safe-settings has been updated to include rulesets. This PR adds to rulesets:
- `Default`: prevents force push & deletion on `main`
- `Pull Requests`: standard PR things (that @renovatebot can bypass when automerging)

Usually I manually create these two, and create a separate status checks one. But we can't do that here, as that would require all repos to have the same named status checks that they won't in general have.