### PR TITLE
Autolink to ARC MyServices tickets

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,6 +13,12 @@ repository:
   squash_merge_commit_message: PR_BODY
   squash_merge_commit_title: PR_TITLE
 
+# See the docs (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources) for a description of autolinks and replacement values.
+autolinks:
+  - key_prefix: "ARCMYS-"
+    url_template: "https://myservices-arc.uk.4me.com/requests/<num>"
+    is_alphanumeric: false
+
 teams:
   - name: mirsg
     permission: admin

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,10 +13,9 @@ repository:
   squash_merge_commit_message: PR_BODY
   squash_merge_commit_title: PR_TITLE
 
-# See the docs (https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources) for a description of autolinks and replacement values.
 autolinks:
-  - key_prefix: "ARCMYS-"
-    url_template: "https://myservices-arc.uk.4me.com/requests/<num>"
+  - key_prefix: ARCMYS-
+    url_template: https://myservices-arc.uk.4me.com/requests/<num>
     is_alphanumeric: false
 
 teams:


### PR DESCRIPTION
Configures autolinks to reference external resources in https://myservices-arc.uk.4me.com/

All tickets can be accessed in the form `https://myservices-arc.uk.4me.com/requests/<request_id>` so this allows references to ARC MyServices tickets to be written in the form `ARCMYS-<request_id>` in all repositories in the UCL-MIRSG org.

E.g. ARCMYS-1581196 would link directly to https://myservices-arc.uk.4me.com/requests/1581196